### PR TITLE
Unescape cookie before decrypting

### DIFF
--- a/lib/crumbl/base.rb
+++ b/lib/crumbl/base.rb
@@ -27,7 +27,7 @@ class Crumbl
 
   def decrypt cookie, secret_key_base
     encryptor = build_message_encryptor(secret_key_base)
-    encryptor.decrypt_and_verify(cookie)
+    encryptor.decrypt_and_verify(CGI.unescape(cookie))
   end
 
   def encrypt data, secret_key_base


### PR DESCRIPTION
In Rails `4.2.0` an exception is thrown when trying to decode a cookie. Unescaping the cookie solves this problem.

```
2.1.5 :005 > puts crumbl.decrypt cookie, secret_key_base
ActiveSupport::MessageVerifier::InvalidSignature: ActiveSupport::MessageVerifier::InvalidSignature
    from /Users/jack/.rvm/gems/ruby-2.1.5@crumbl/gems/activesupport-4.2.0/lib/active_support/message_verifier.rb:49:in `verify'
    from /Users/jack/.rvm/gems/ruby-2.1.5@crumbl/gems/activesupport-4.2.0/lib/active_support/message_encryptor.rb:64:in `decrypt_and_verify'
    from /Users/jack/Code/ruby/crumbl/lib/crumbl/base.rb:30:in `decrypt'
    from (irb):5
    from /Users/jack/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
```
